### PR TITLE
Add Dark Mode Toggle with Logo Swap

### DIFF
--- a/src/cis/AboutCIS.jsx
+++ b/src/cis/AboutCIS.jsx
@@ -26,7 +26,7 @@ function AboutCIS() {
                     onMouseLeave={() => setHovered(false)}
                     style={{ minHeight: '200px' }}
                 >
-                    <div className='absolute z-[5] bg-white left-[30%] top-[13%] px-[25%] py-[17%]'></div>
+                    <div className='absolute z-[5] left-[30%] top-[13%] px-[25%] py-[17%]'></div>
                     <img className="absolute z-10 w-[90%]" src={cis} alt="CIS Logo" />
                     {emojis.map((emoji, i) => (
                         <span

--- a/src/cis/ContactCIS.css
+++ b/src/cis/ContactCIS.css
@@ -25,3 +25,45 @@
 .button-container a:hover{
     box-shadow: 0px 1px 1px 1px rgba(0,0,0,0.25);
 }
+
+/* Form labels */
+body.dark .label-feedback {
+    color: #f1f1f1 !important;
+    text-shadow: none !important;
+}
+
+/* Inputs & textareas */
+body.dark input,
+body.dark textarea {
+    background-color: #222 !important;
+    color: #f1f1f1 !important;
+    border: 1px solid #444 !important;
+}
+
+body.dark input::placeholder,
+body.dark textarea::placeholder {
+    color: #aaa !important;
+}
+
+/* Buttons inside contact section only */
+body.dark #contact button {
+    background-color: #333 !important;
+    color: #f1f1f1 !important;
+    border: 2px solid #444 !important;
+}
+
+body.dark #contact button:hover {
+    border: 2px solid #ffffff !important;
+}
+
+/* Social icons inside contact section only */
+body.dark #contact .button-container a {
+    background-color: #333 !important;
+    box-shadow: 0px 4px 4px 2px rgba(255,255,255,0.1) !important;
+}
+
+body.dark #contact .button-container a:hover {
+    border: 2px solid #ffffff !important;
+}
+
+

--- a/src/cis/NavbarCIS.css
+++ b/src/cis/NavbarCIS.css
@@ -2,7 +2,10 @@
     width: 100%;
     height: 12vh;
     display: grid;
-    grid-template-columns: 10% 90%;
+    grid-template-columns: 10% auto;
+    align-items: center;
+    background-color: white;
+    padding: 0 5%;
 }
 
 .navbar-cis img {
@@ -17,42 +20,95 @@
     justify-self: end;
     align-self: center;
     margin-right: 5%;
-    width: 30%;
-    ul{
-        display: flex;
-        justify-content: space-between;
-        li button{
-            font-family: 'Arima';
-            font-weight: 400;
-            padding-bottom: 2%;
-            margin-left: 5%;
-            cursor: pointer;
-            border-bottom: 2px solid transparent;
-            &.active, &:hover {
-                border-bottom-color: #3EA2DC;
-            }
-        }
-    }
+    width: auto; /* allow nav items to take space dynamically */
 }
 
+.navbar-cis nav ul {
+    display: flex;
+    align-items: center;
+    gap: 24px; /* spacing between nav items */
+}
+
+.navbar-cis nav ul li button {
+    font-family: 'Arima';
+    font-weight: 400;
+    font-size: 16px;
+    white-space: nowrap;
+    cursor: pointer;
+    border: none;
+    background: none;
+    padding: 4px 0;  /* space for underline */
+    border-bottom: 2px solid transparent; /* reserve space */
+    transition: border-bottom-color 0.2s ease;
+}
+
+.navbar-cis nav ul li button.active,
+.navbar-cis nav ul li button:hover {
+    border-bottom-color: #3EA2DC; /* blue underline */
+}
+
+.nav-logo {
+  height: 6vh;   /* scales with screen height */
+  width: auto;
+  object-fit: contain;
+}
+
+/* Dark mode global styles */
+body.dark {
+    background-color: #121212;
+    color: #f1f1f1;
+}
+
+/* Make navbar adapt to dark mode */
+body.dark .navbar-cis {
+    background-color: #1e1e1e;
+}
+
+/* Dark mode toggle button */
+.dark-toggle-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background-color 0.3s ease;
+    
+}
+
+/* Make SVG inherit text color */
+.dark-toggle-btn svg {
+    width: 20px;
+    height: 20px;
+    fill: #333; /* visible in light mode */
+}
+
+body.dark .dark-toggle-btn svg {
+    fill: #f1f1f1; /* visible in dark mode */
+}
+
+/* Responsive adjustments */
 @media screen and (max-width: 640px) {
     .navbar-cis {
         height: 10vh;
-        grid-template-columns: 30% 70%;
+        grid-template-columns: 30% auto;
+        padding: 0 3%;
     }
+
     .navbar-cis img {
         margin-left: 5%;
         width: 80%;
         height: 50%;
     }
-    .navbar-cis nav {
-        width: 80%;
-        margin-right: 4%;
-        ul{
-            li button{
-                font-size: 12px;
-                margin-left: 5%;
-            }
-        }
+
+    .navbar-cis nav ul {
+        gap: 12px; /* reduce spacing on mobile */
+    }
+
+    .navbar-cis nav ul li button {
+        font-size: 12px;
     }
 }

--- a/src/cis/NavbarCIS.jsx
+++ b/src/cis/NavbarCIS.jsx
@@ -1,22 +1,52 @@
-import logo from '../assets/cis_black_logo.png';
+import { useState } from "react";
+import logoDark from '../assets/cis_blue_logo.png'
+import logoLight from '../assets/cis_black_logo.png';
 import ScrollIntoView from 'react-scroll-into-view';
 import "./NavbarCIS.css";
 
+// Simple inline SVGs for sun/moon
+const MoonIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" 
+    viewBox="0 0 24 24" width="20" height="20">
+    <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+  </svg>
+);
+
+const SunIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-sun" viewBox="0 0 16 16"> 
+    <path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6m0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8M8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0m0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13m8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5M3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8m10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0m-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0m9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707M4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708"/>
+
+  </svg>
+);
+
 function NavbarCIS() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  const toggleDarkMode = () => {
+    setDarkMode(!darkMode);
+    document.body.classList.toggle("dark", !darkMode);
+  };
+
   return (
     <div className="navbar-cis">
-      <img className="" src={logo} alt="Logo" />
+      <img src={darkMode ? logoDark : logoLight} alt="Logo" className="nav-logo"/>
       <nav>
         <ul>
           <li><ScrollIntoView selector='#home'><button>Home</button></ScrollIntoView></li>
-          <li><ScrollIntoView selector='#about'><button className='w-[100%]'>About us</button></ScrollIntoView></li>
+          <li><ScrollIntoView selector='#about'><button>About us</button></ScrollIntoView></li>
           <li><ScrollIntoView selector='#stats'><button>Statistics</button></ScrollIntoView></li>
           <li><ScrollIntoView selector='#team'><button>Team</button></ScrollIntoView></li>
           <li><ScrollIntoView selector='#contact'><button>Contact</button></ScrollIntoView></li>
+
+          {/* Dark Mode Toggle Icon */}
+          <li>
+            <button className="dark-toggle-btn" onClick={toggleDarkMode}>
+              {darkMode ? <SunIcon /> : <MoonIcon />}
+            </button>
+          </li>
         </ul>
       </nav>
     </div>
-
   );
 }
 


### PR DESCRIPTION
This PR introduces **dark mode support** across the site with the following changes:

* **Navbar**

  * Added a 🌙/☀️ toggle button.
  * Implemented logo swap (light → dark logo) depending on theme.
  * Ensured navbar remains fixed at top without overlapping hero section.

* **Contact Section**

  * Applied dark mode overrides for form inputs, textareas, and buttons.
  * Updated social media cards to adapt to dark backgrounds.
  * Scoped styles (`#contact`) to avoid interfering with navbar buttons.

* **UI Improvements**

  * Fixed underline hover effect in navbar links.
  * Balanced logo sizes (light logo 825×359, dark logo 722×398) using `vh` units for consistent scaling.
  * Improved dark mode hover styles (softer hover state for better contrast).

**How to test:**

1. Run `npm run dev`.
2. Toggle 🌙/☀️ button in navbar.
3. Verify:

   * Navbar + logo swap.
   * Contact form (inputs, buttons, socials) adapt to dark mode.
   * Hover effects remain consistent.

**Screenshots:**
<img width="1439" height="784" alt="Screenshot 2025-09-29 at 6 35 07 PM" src="https://github.com/user-attachments/assets/bc6e2ae3-3c4e-4554-8ae0-36cb0a3aac92" />
<img width="1440" height="785" alt="Screenshot 2025-09-29 at 6 35 50 PM" src="https://github.com/user-attachments/assets/21458684-2e26-44d2-b77f-56ba79e05db2" />

